### PR TITLE
Fixed two bugs

### DIFF
--- a/CrossPare/src/main/java/de/ugoe/cs/cpdp/dataselection/SeparatabilitySelection.java
+++ b/CrossPare/src/main/java/de/ugoe/cs/cpdp/dataselection/SeparatabilitySelection.java
@@ -79,6 +79,7 @@ public class SeparatabilitySelection implements ISetWiseDataselectionStrategy {
             for (int rep = 0; rep < this.maxRep; rep++) {
                 // sample instances
                 Instances sample = new Instances(testdata);
+                sample.clear();
                 for (int j = 0; j < this.sampleSize; j++) {
                     Instance inst =
                         new DenseInstance(testdata.instance(rand.nextInt(testdata.numInstances())));

--- a/CrossPare/src/main/java/de/ugoe/cs/cpdp/training/WekaLocalFQTraining.java
+++ b/CrossPare/src/main/java/de/ugoe/cs/cpdp/training/WekaLocalFQTraining.java
@@ -220,7 +220,7 @@ public class WekaLocalFQTraining extends WekaBaseTraining implements ITrainingSt
                 Instance classInstance = createInstance(traindata, instance);
 
                 // this one keeps the class attribute
-                Instances traindata2 = this.ctraindata.get(1);
+                Instances traindata2 = this.ctraindata.get(0);
 
                 // remove class attribute before clustering
                 Remove filter = new Remove();


### PR DESCRIPTION
Hi,

Two bugs were found.
A fix on SeparatabilitySelection deleted instances already in a variable sample.
With this fix, the variable would have the equal number of instances from testdata and traindata.

Another fix on WekaLocalFQTraining makes it avoid a corner case that ctraindata only has one element. Sometimes it happens and cause NullPointerException.
