### PR TITLE
Changed gradle build to Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - openjdk8
+  - openjdk11
   
 script:
   - cd CrossPare

--- a/CrossPare/build.gradle
+++ b/CrossPare/build.gradle
@@ -59,3 +59,9 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 }
 
+/* Removes transitive dependency on xerces which fixes 
+"the package is accessible from more than one module" - error
+for javax.xml.parsers as well as org.xml.sax */
+configurations {
+    all*.exclude group: 'xerces'
+}

--- a/CrossPare/build.gradle
+++ b/CrossPare/build.gradle
@@ -11,8 +11,8 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility  = 1.8
-targetCompatibility  = 1.8
+sourceCompatibility  = 11
+targetCompatibility  = 11
 
 dependencies {
 /*
@@ -23,38 +23,38 @@ dependencies {
 	compile group: 'RoSuDA', name: 'JRIEngine', version: '0.5-0'
 */
        
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.5'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.5'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-iostreams', version: '2.5'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.5'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.5'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-iostreams', version: '2.5'
     
-    compile group: 'nz.ac.waikato.cms.weka', name: 'weka-stable', version: '3.8.3'
-    compile group: 'nz.ac.waikato.cms.weka', name: 'alternatingDecisionTrees', version: '1.0.5'
-    compile group: 'nz.ac.waikato.cms.weka', name: 'probabilisticSignificanceAE', version: '1.0.2'
-    compile group: 'nz.ac.waikato.cms.weka', name: 'RBFNetwork', version: '1.0.8'
+    implementation group: 'nz.ac.waikato.cms.weka', name: 'weka-stable', version: '3.8.3'
+    implementation group: 'nz.ac.waikato.cms.weka', name: 'alternatingDecisionTrees', version: '1.0.5'
+    implementation group: 'nz.ac.waikato.cms.weka', name: 'probabilisticSignificanceAE', version: '1.0.2'
+    implementation group: 'nz.ac.waikato.cms.weka', name: 'RBFNetwork', version: '1.0.8'
     
-    compile group: 'org.apache.commons', name: 'commons-math3', version: '3.5'
-    compile group: 'commons-io', name: 'commons-io', version: '2.4'
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
-	compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
-	compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.0'
+    implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.5'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.4'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
+	implementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
+	implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.0'
 	
-	compile group: 'com.google.guava', name: 'guava', version: '19.0'
+	implementation group: 'com.google.guava', name: 'guava', version: '19.0'
 	
-	compile group: 'org.uma.jmetal', name: 'jmetal-core', version: '5.0'
-	compile group: 'org.uma.jmetal', name: 'jmetal-exec', version: '5.0'
-	compile group: 'org.uma.jmetal', name: 'jmetal-algorithm', version: '5.0'
+	implementation group: 'org.uma.jmetal', name: 'jmetal-core', version: '5.0'
+	implementation group: 'org.uma.jmetal', name: 'jmetal-exec', version: '5.0'
+	implementation group: 'org.uma.jmetal', name: 'jmetal-algorithm', version: '5.0'
 	
-	compile group: 'org.ojalgo', name: 'ojalgo', version: '37.1.1'
+	implementation group: 'org.ojalgo', name: 'ojalgo', version: '37.1.1'
 	
-	compile group: 'mysql', name: 'mysql-connector-java', version: '5.1.38'
+	implementation group: 'mysql', name: 'mysql-connector-java', version: '5.1.38'
 	
-	compile group: 'de.lmu.ifi.dbs.elki', name: 'elki', version: '0.7.5'
+	implementation group: 'de.lmu.ifi.dbs.elki', name: 'elki', version: '0.7.5'
 	
-	compile group: 'org.json', name: 'json', version: '20160810'
+	implementation group: 'org.json', name: 'json', version: '20160810'
 	
-	compile group: 'net.sf.jgap', name: 'jgap', version: '3.4.4'
+	implementation group: 'net.sf.jgap', name: 'jgap', version: '3.4.4'
 
-    compile fileTree(include: ['*.jar'], dir: 'lib')
+    implementation fileTree(include: ['*.jar'], dir: 'lib')
 	// Use JUnit test framework
     testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
This adds Java 11 to gradle build and travis and fixes corresponding "the package is accessible from more than one module" - error by removing a transitive dependency on xerces.